### PR TITLE
Actor attack

### DIFF
--- a/Assets/Resources/Prefab/Enemy.prefab
+++ b/Assets/Resources/Prefab/Enemy.prefab
@@ -15,7 +15,7 @@ GameObject:
   - component: {fileID: 2781783833759806821}
   m_Layer: 0
   m_Name: Enemy
-  m_TagString: Untagged
+  m_TagString: Enemy
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -3755,6 +3755,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1482730804}
   - component: {fileID: 1482730805}
+  - component: {fileID: 1482730806}
   m_Layer: 0
   m_Name: Player Attack Collider
   m_TagString: Untagged
@@ -3803,6 +3804,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &1482730806
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1482730803}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: baa4681491450d84d88006a422a13ff3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2011757129
 GameObject:
   m_ObjectHideFlags: 3
@@ -16784,7 +16797,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &2051534364
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -221,7 +221,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 1482730804}
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -3744,6 +3745,64 @@ Transform:
   m_Father: {fileID: 2051534364}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1482730803
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1482730804}
+  - component: {fileID: 1482730805}
+  m_Layer: 0
+  m_Name: Player Attack Collider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1482730804
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1482730803}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 372495657}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &1482730805
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1482730803}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
 --- !u!1 &2011757129
 GameObject:
   m_ObjectHideFlags: 3

--- a/Assets/Scripts/Actor/Actor.cs
+++ b/Assets/Scripts/Actor/Actor.cs
@@ -1,6 +1,4 @@
 
-using System;
-using System.Collections.Generic;
 using Interface;
 using UnityEngine;
 
@@ -9,7 +7,7 @@ namespace Actor
     // Values or methods that other can use
     public abstract partial class Actor
     {
-        public abstract void GetHit();
+        public abstract void GetHit(int damage);
         protected abstract void Died();
     }
     

--- a/Assets/Scripts/Actor/Actor.cs
+++ b/Assets/Scripts/Actor/Actor.cs
@@ -7,7 +7,7 @@ namespace Actor
     // Values or methods that other can use
     public abstract partial class Actor
     {
-        public abstract void GetHit(int damage);
+        public abstract void GetHit(DamageData data);
         protected abstract void Died();
     }
     

--- a/Assets/Scripts/Actor/Enemy/DiedState.cs
+++ b/Assets/Scripts/Actor/Enemy/DiedState.cs
@@ -1,0 +1,21 @@
+
+using StateMachine;
+
+namespace Actor.Enemy
+{
+    public class DiedState : State<Enemy>
+    {
+        public override void OnInitialized()
+        {
+        }
+
+        public override void OnEnter()
+        {
+            // 
+        }
+            
+        public override void Update()
+        {
+        }
+    }
+}

--- a/Assets/Scripts/Actor/Enemy/DiedState.cs.meta
+++ b/Assets/Scripts/Actor/Enemy/DiedState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b1916802273449e4c9820ddb3b56aaf0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Actor/Enemy/Enemy.cs
+++ b/Assets/Scripts/Actor/Enemy/Enemy.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using Actor.Stats;
+using Interface;
 using StateMachine;
 using UnityEngine;
 using UnityEngine.Pool;
@@ -12,6 +13,8 @@ namespace Actor.Enemy
     public partial class Enemy
     {
         protected StateMachine<Enemy> stateMachine;
+        
+        internal Rigidbody2D Rigidbody2D;
         internal GameObject Target => _target;
         internal EnemyStatObject Stat => _stat;
         public SerializedDictionary<AttributeType, int> currentAttributes;
@@ -19,7 +22,7 @@ namespace Actor.Enemy
         protected int baseHealthPoint;
         protected int currentHealthPoint;
         
-        public override void GetHit(int damage) => _GetHit(damage);
+        public override void GetHit(DamageData data) => _GetHit(data);
         public void SetManagedPool(IObjectPool<Enemy> pool) => _SetManagedPool(pool);
         public void Init() => _Init();
 
@@ -45,9 +48,14 @@ namespace Actor.Enemy
     // body of MonoBehaviour
     public partial class Enemy : Actor
     {
+        private void Awake()
+        {
+            Rigidbody2D = GetComponent<Rigidbody2D>();
+            _target = GameObject.Find("Player");
+        }
+        
         private void Start()
         {
-            _target = GameObject.Find("Player");
             stateMachine = new StateMachine<Enemy>(this, new IdleState());
             stateMachine.AddState(new MoveState());
             stateMachine.AddState(new AttackState());
@@ -63,18 +71,22 @@ namespace Actor.Enemy
             stateMachine.FixedUpdate();
         }
 
-        private void OnTriggerEnter(Collider other)
-        {
-            throw new System.NotImplementedException();
-        }
+        // private void OnTriggerEnter2D(Collider2D other)
+        // {
+        //     // TODO : Call _GetHit function of Player
+        //     
+        //     throw new System.NotImplementedException();
+        // }
     }
     
     // body of others
     public partial class Enemy
     {
-        private void _GetHit(int damage)
+        private void _GetHit(DamageData data)
         {
-            throw new System.NotImplementedException();
+            Debug.Log(data.Damage + "health Lost");
+            // TODO : make GetHitState of Enemy
+            Rigidbody2D.AddForce(data.KbForce, ForceMode2D.Impulse);
         }
 
         protected override void Died()

--- a/Assets/Scripts/Actor/Enemy/Enemy.cs
+++ b/Assets/Scripts/Actor/Enemy/Enemy.cs
@@ -85,13 +85,14 @@ namespace Actor.Enemy
         private void _GetHit(DamageData data)
         {
             Debug.Log(data.Damage + "health Lost");
-            // TODO : make GetHitState of Enemy
+            // TODO : make GetHitState of Enemy and put Addforce func in it
             Rigidbody2D.AddForce(data.KbForce, ForceMode2D.Impulse);
         }
 
         protected override void Died()
         {
             throw new System.NotImplementedException();
+            // TODO : make 
         }
         
         private void _Init()

--- a/Assets/Scripts/Actor/Enemy/Enemy.cs
+++ b/Assets/Scripts/Actor/Enemy/Enemy.cs
@@ -19,7 +19,7 @@ namespace Actor.Enemy
         protected int baseHealthPoint;
         protected int currentHealthPoint;
         
-        public override void GetHit() => _GetHit();
+        public override void GetHit(int damage) => _GetHit(damage);
         public void SetManagedPool(IObjectPool<Enemy> pool) => _SetManagedPool(pool);
         public void Init() => _Init();
 
@@ -62,12 +62,17 @@ namespace Actor.Enemy
         {
             stateMachine.FixedUpdate();
         }
+
+        private void OnTriggerEnter(Collider other)
+        {
+            throw new System.NotImplementedException();
+        }
     }
     
     // body of others
     public partial class Enemy
     {
-        private void _GetHit()
+        private void _GetHit(int damage)
         {
             throw new System.NotImplementedException();
         }

--- a/Assets/Scripts/Actor/Enemy/GetHitState.cs
+++ b/Assets/Scripts/Actor/Enemy/GetHitState.cs
@@ -1,0 +1,21 @@
+
+using StateMachine;
+
+namespace Actor.Enemy
+{
+    public class GetHitState : State<Enemy>
+    {
+        public override void OnInitialized()
+        {
+        }
+
+        public override void OnEnter()
+        {
+            // 
+        }
+            
+        public override void Update()
+        {
+        }
+    }
+}

--- a/Assets/Scripts/Actor/Enemy/GetHitState.cs.meta
+++ b/Assets/Scripts/Actor/Enemy/GetHitState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a6b1d9d0c72bbb745a18b4c0b4461f92
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Actor/Enemy/MoveState.cs
+++ b/Assets/Scripts/Actor/Enemy/MoveState.cs
@@ -9,13 +9,11 @@ namespace Actor.Enemy
 {
     public class MoveState : State<Enemy>
     {
-        private Rigidbody2D _rigidbody2D;
         private Transform _playerPos;
         private int _speed => _context.currentAttributes[AttributeType.Speed];
 
         public override void OnInitialized()
         {
-            _rigidbody2D = _context.GetComponent<Rigidbody2D>();
             _playerPos = _context.Target.transform;
         }
 
@@ -28,7 +26,7 @@ namespace Actor.Enemy
             if (!_context.IsAttackable)
             {
                 Vector2 pos = Vector3.Normalize(_playerPos.position - _context.transform.position);
-                _rigidbody2D.MovePosition(_rigidbody2D.position + _speed * Time.fixedDeltaTime * pos);
+                _context.Rigidbody2D.MovePosition(_context.Rigidbody2D.position + _speed * Time.fixedDeltaTime * pos);
             }
             else
             {

--- a/Assets/Scripts/Actor/Player/Player.cs
+++ b/Assets/Scripts/Actor/Player/Player.cs
@@ -1,9 +1,11 @@
 
 using System;
-using Actor.Stats;
-using StateMachine;
 using UnityEngine;
 using UnityEngine.InputSystem;
+
+using Actor.Stats;
+using Interface;
+using StateMachine;
 
 namespace Actor.Player
 {
@@ -11,7 +13,7 @@ namespace Actor.Player
     public partial class Player
     {
         protected StateMachine<Player> StateMachine;
-        public override void GetHit(int damage) => _GetHit(damage);
+        public override void GetHit(DamageData data) => _GetHit(data);
 
         internal Vector2 Movement;
         internal Vector2 Stareing;
@@ -65,17 +67,12 @@ namespace Actor.Player
         {
             StateMachine.FixedUpdate();
         }
-
-        private void OnTriggerEnter(Collider other)
-        {
-            throw new NotImplementedException();
-        }
     }
     
     // body of others
     public partial class Player
     {
-        private void _GetHit(int damage)
+        private void _GetHit(DamageData data)
         {
             throw new System.NotImplementedException();
         }

--- a/Assets/Scripts/Actor/Player/Player.cs
+++ b/Assets/Scripts/Actor/Player/Player.cs
@@ -1,9 +1,9 @@
 
+using System;
 using Actor.Stats;
 using StateMachine;
 using UnityEngine;
 using UnityEngine.InputSystem;
-using UnityEngine.Rendering;
 
 namespace Actor.Player
 {
@@ -11,12 +11,14 @@ namespace Actor.Player
     public partial class Player
     {
         protected StateMachine<Player> StateMachine;
-        public override void GetHit() => _GetHit();
+        public override void GetHit(int damage) => _GetHit(damage);
 
         internal Vector2 Movement;
+        internal Vector2 Stareing;
 
         internal Animator PlayerAnim;
         internal Rigidbody2D PlayerRigid;
+        internal GameObject PlayerAttackCol;
 
         public PlayerStatObject Stat
         {
@@ -42,6 +44,8 @@ namespace Actor.Player
         {
             PlayerAnim = GetComponent<Animator>();
             PlayerRigid = GetComponent<Rigidbody2D>();
+            PlayerAttackCol = transform.GetChild(0).gameObject;
+            PlayerAttackCol.gameObject.SetActive(false);
         }
         
         private void Start()
@@ -61,12 +65,17 @@ namespace Actor.Player
         {
             StateMachine.FixedUpdate();
         }
+
+        private void OnTriggerEnter(Collider other)
+        {
+            throw new NotImplementedException();
+        }
     }
     
     // body of others
     public partial class Player
     {
-        private void _GetHit()
+        private void _GetHit(int damage)
         {
             throw new System.NotImplementedException();
         }
@@ -79,6 +88,10 @@ namespace Actor.Player
         private void OnMovement(InputValue value)
         {
             Movement = value.Get<Vector2>();
+            if (!Movement.Equals(Vector2.zero))
+            {
+                Stareing = Movement;
+            }
         }
 
         private void OnAutoAttack(InputValue value)

--- a/Assets/Scripts/Actor/Player/PlayerAttackCol.cs
+++ b/Assets/Scripts/Actor/Player/PlayerAttackCol.cs
@@ -1,0 +1,11 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Actor.Player
+{
+    public class PlayerAttackCol : MonoBehaviour
+    {
+        
+    }
+}

--- a/Assets/Scripts/Actor/Player/PlayerAttackCol.cs
+++ b/Assets/Scripts/Actor/Player/PlayerAttackCol.cs
@@ -1,10 +1,43 @@
-using System.Collections;
-using System.Collections.Generic;
+
+using Interface;
 using UnityEngine;
 
 namespace Actor.Player
 {
-    public class PlayerAttackCol : MonoBehaviour
+    // Values or methods that other can use
+    public partial class PlayerAttackCol
+    {
+        public DamageData DmgData;
+    }
+    
+    // Values or methods that other cannot use
+    public partial class PlayerAttackCol
+    {
+        private Player _player;
+    }
+
+    // body of MonoBehaviour
+    public partial class PlayerAttackCol : MonoBehaviour
+    {
+        private void Awake()
+        {
+            _player = transform.parent.GetComponent<Player>();
+            DmgData.Damage = 5;
+        }
+
+        private void OnTriggerEnter2D(Collider2D other)
+        {
+            if (other.CompareTag("Enemy"))
+            {
+                // TOD0 : Set KnockBackForce power
+                DmgData.KbForce = Vector3.Normalize(_player.transform.position - other.transform.position);
+                other.GetComponent<Enemy.Enemy>().GetHit(DmgData);
+            }
+        }
+    }
+    
+    // body of others
+    public partial class PlayerAttackCol
     {
         
     }

--- a/Assets/Scripts/Actor/Player/PlayerAttackCol.cs.meta
+++ b/Assets/Scripts/Actor/Player/PlayerAttackCol.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: baa4681491450d84d88006a422a13ff3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Actor/Player/PlayerAttackState.cs
+++ b/Assets/Scripts/Actor/Player/PlayerAttackState.cs
@@ -53,8 +53,8 @@ namespace Actor.Player
         private void _SetAttackCol()
         {
             Vector2 t = new Vector2(Mathf.Abs(_context.Stareing.y), Mathf.Abs(_context.Stareing.x));
-            _atkPos.localScale = t * 0.75f + new Vector2(0.75f, 0.75f);;
-            _atkPos.localPosition = _context.Stareing * 0.75f;
+            _atkPos.localScale = t * 0.5f + new Vector2(1, 1);;
+            _atkPos.localPosition = _context.Stareing * 0.5f;
         }
 
         private void _GiveDamage()

--- a/Assets/Scripts/Actor/Player/PlayerAttackState.cs
+++ b/Assets/Scripts/Actor/Player/PlayerAttackState.cs
@@ -7,9 +7,22 @@ namespace Actor.Player
 {
     public class PlayerAttackState : State<Player>
     {
+        private Transform _atkPos;
+        private Collider2D _atkCol;
+        
+        public override void OnInitialized()
+        {
+            _atkPos = _context.PlayerAttackCol.transform;
+            _atkCol = _context.PlayerAttackCol.GetComponent<BoxCollider2D>();
+        }
+        
         public override void OnEnter()
         {
             _context.PlayerAnim.SetBool(Animator.StringToHash("isAttacking"), true);
+            
+            _context.PlayerAttackCol.SetActive(true);
+            _SetAttackCol();
+            
             _context.StartCoroutine(_AttackSpeed());
         }
         
@@ -31,8 +44,22 @@ namespace Actor.Player
         
         private IEnumerator _AttackSpeed()
         {
-            yield return new WaitForSeconds(0.5f);
+            yield return new WaitForSeconds(0.1f);
+            _context.PlayerAttackCol.SetActive(false);
+            yield return new WaitForSeconds(0.4f);
             _Finish();
+        }
+
+        private void _SetAttackCol()
+        {
+            Vector2 t = new Vector2(Mathf.Abs(_context.Stareing.y), Mathf.Abs(_context.Stareing.x));
+            _atkPos.localScale = t * 0.75f + new Vector2(0.75f, 0.75f);;
+            _atkPos.localPosition = _context.Stareing * 0.75f;
+        }
+
+        private void _GiveDamage()
+        {
+            
         }
     }
 }

--- a/Assets/Scripts/Actor/Player/PlayerMoveState.cs
+++ b/Assets/Scripts/Actor/Player/PlayerMoveState.cs
@@ -31,8 +31,8 @@ namespace Actor.Player
             }
             else
             {
-                _context.PlayerAnim.SetFloat(_moveXid, _context.Movement.x);
-                _context.PlayerAnim.SetFloat(_moveYid, _context.Movement.y);
+                _context.PlayerAnim.SetFloat(_moveXid, _context.Stareing.x);
+                _context.PlayerAnim.SetFloat(_moveYid, _context.Stareing.y);
             }
         }
         

--- a/Assets/Scripts/Interface/IDamageable.cs
+++ b/Assets/Scripts/Interface/IDamageable.cs
@@ -1,10 +1,12 @@
 
 
+using UnityEngine;
+
 namespace Interface
 {
     public interface IDamageable
     {
-        void GetHit();
+        void GetHit(int damage);
     }
 }
 

--- a/Assets/Scripts/Interface/IDamageable.cs
+++ b/Assets/Scripts/Interface/IDamageable.cs
@@ -1,12 +1,17 @@
 
-
 using UnityEngine;
 
 namespace Interface
 {
+    public struct DamageData
+    {
+        public int Damage;
+        public Vector3 KbForce;
+    }
+    
     public interface IDamageable
     {
-        void GetHit(int damage);
+        void GetHit(DamageData data);
     }
 }
 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -3,7 +3,9 @@
 --- !u!78 &1
 TagManager:
   serializedVersion: 2
-  tags: []
+  tags:
+  - PlayerAttackCol
+  - Enemy
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
[시연 영상 링크](https://youtu.be/CXfEiE0jn2M)

## 구현사항

### 플레이어 기본공격
- 공격 콜라이더는 플레이어의 자식 오브젝트로 하여 따로 지정해 두었습니다.
- 플레이어는 이 콜라이더에 데미지에 관한 데이터를 집어넣고, 콜라이더의 크기를 조절해 활성화시켜 공격을 할 수 있습니다.

### 적 피격
- 플레이어 공격 콜라이더에 피격당한 적은 콜라이더에 의해 GetHit함수가 호출됩니다.
- 해당 함수는 받은 데미지, 넉백당하는 힘의 벡터 등이 들어있는 데미지 데이터를 매개변수로 받습니다.

## 추후 구현할 사항

### 적 애니메이션
 - 적의 기본상태, 이동상태, 피격상태, 사망상태, 공격상태에 연동되는 애니메이션을 구현할 예정입니다.

### 적 공격
 - 적의 공격상태일 때 플레이어를 공격하여 플레이어의 체력을 닳게 하는 기능을 구현할 예정입니다.