### PR TITLE
FIX: stat sync

### DIFF
--- a/Assets/Scenes/BattleScene.unity
+++ b/Assets/Scenes/BattleScene.unity
@@ -157,19 +157,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f755df9d694d16140baa783ff605c4ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  currentAttributes:
-    keys: 
-    values: []
-  skillEffectValues:
-    keys: 
-    values: []
   stat: {fileID: 11400000, guid: c6d6312bbd5c7884bb273850f3b45774, type: 2}
+  _skillEffectedValues:
+    keys: 
+    values: []
   attackCollider: {fileID: 1482730803}
   forwardVector: {x: 0, y: 0}
-  launcher: {fileID: 0}
-  _itemEffectValues:
-    m_Keys: 
-    m_Values: []
+  launcher: {fileID: 1040016780}
+  _itemEffectedValues:
+    keys: 
+    values: []
 --- !u!212 &372495656
 SpriteRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Actor/Enemy/EnemyMoveState.cs
+++ b/Assets/Scripts/Actor/Enemy/EnemyMoveState.cs
@@ -10,7 +10,7 @@ namespace Actor.Enemy
     public class EnemyMoveState : State<Enemy>
     {
         private Transform _playerPos;
-        private float _speed => _context.currentAttributes[AttributeType.MoveSpeed].value;
+        private float _speed => _context.GetAttributeValue(AttributeType.MoveSpeed);
         
         private int _moveXid;
         private int _moveYid;

--- a/Assets/Scripts/Actor/Player/Player.cs
+++ b/Assets/Scripts/Actor/Player/Player.cs
@@ -17,6 +17,7 @@ namespace Actor.Player
         internal Animator PlayerAnim;
         internal Rigidbody2D PlayerRigid;
 
+        public float PercentHealPoint => stat.PercentHealPoint;
         public override float GetAttributeValue(AttributeType type) => stat.currentAttributes[type].value;
         public override void AddAttributeValue(AttributeType type, float value) => stat.AddAttribute(type, value);
         public override void AddEffect(Effect effect) => stat.AddEffect(effect);

--- a/Assets/Scripts/Actor/Player/Player.cs
+++ b/Assets/Scripts/Actor/Player/Player.cs
@@ -121,6 +121,7 @@ namespace Actor.Player
             ElementalBalancer.ApplyElementalEffect(data.ElementalType, ref effect);
             if (effect != null)
                 Affected(effect);
+            Debug.Log("Player HP: " + (stat.PercentHealPoint * 100) + "%");
         }
     }
 

--- a/Assets/Scripts/Actor/Player/Player.cs
+++ b/Assets/Scripts/Actor/Player/Player.cs
@@ -1,25 +1,31 @@
 using System;
 using UnityEngine;
 using UnityEngine.InputSystem;
-using UnityEngine.Rendering;
 using Actor.Stats;
+using Core;
+using Elemental;
 using StateMachine;
 using Interface;
-using Unity.VisualScripting;
 
 namespace Actor.Player
 {
     // Values or methods that other can use
     public partial class Player
     {
-        protected StateMachine<Player> StateMachine;
-
         internal Vector2 Movement;
 
         internal Animator PlayerAnim;
         internal Rigidbody2D PlayerRigid;
 
-        public PlayerStatObject Stat => stat;
+        public override float GetAttributeValue(AttributeType type) => stat.currentAttributes[type].value;
+        public override void AddAttributeValue(AttributeType type, float value) => stat.AddAttribute(type, value);
+        public override void AddEffect(Effect effect) => stat.AddEffect(effect);
+        public override void DeleteEffect(EffectType type) => stat.DeleteEffect(type);
+
+        protected override void Died()
+        {
+            StateMachine.ChangeState<PlayerDiedState>();
+        }
     }
     
     // Values or methods that other cannot use
@@ -28,7 +34,16 @@ namespace Actor.Player
         private Vector2 _movement;
         private PlayerInput _playerInput;
         
-        [SerializeField] private SerializedDictionary<AttributeType, float> _itemEffectValues;
+        private StateMachine<Player> StateMachine;
+        [SerializeField] private SerializableDictionary<AttributeType, float> _itemEffectedValues;
+
+        private void UseSkill(int index)
+        {
+            if (stat.skills[index] == null)
+                return;
+            StateMachine.ChangeState<PlayerAttackState>();
+            stat.skills[index].UseSkill();
+        }
     }
     
     // body of MonoBehaviour
@@ -45,7 +60,10 @@ namespace Actor.Player
             StateMachine.AddState(new PlayerMoveState());
             StateMachine.AddState(new PlayerAttackState());
             StateMachine.AddState(new PlayerDiedState());
-            
+        }
+
+        protected void OnEnable()
+        {
             attackCollider.GetComponent<PlayerAttackCol>().OnAttackTrigger += stat.normalAttack.OnAttackTrigger;
             launcher.OnAttackTrigger += stat.skills[0].OnAttackTrigger;
         }
@@ -80,36 +98,29 @@ namespace Actor.Player
     // body of others
     public partial class Player
     {
+        public override void Affected(Effect effect)
+        {
+            foreach (var type in effect.effectTo)
+            {
+                _skillEffectedValues[type] += effect.GetValueToAdd(GetAttributeValue(type));
+            }
+            AddEffect(effect);
+            // TODO: set current attributes
+            // TODO: event call 
+        }
+
+        public override void Released(Effect effect)
+        {
+            throw new NotImplementedException();
+        }
+        
         public override void Damaged(DamageData data)
         {
-            stat.currentHealthPoint -= data.Damage;
-        }
-
-        protected override void Died()
-        {
-            StateMachine.ChangeState<PlayerDiedState>();
-        }
-
-        private void OnEquipItem()
-        {
-            foreach (AttributeType type in Enum.GetValues(typeof(AttributeType)))
-            {
-                AddAttributeValue(type, -(_itemEffectValues[type]));
-            }
-
-            // calculate stats effect
-            foreach (AttributeType type in Enum.GetValues(typeof(AttributeType)))
-            {
-                AddAttributeValue(type, _itemEffectValues[type]);
-            }
-        }
-
-        private void UseSkill(int index)
-        {
-            if (stat.skills[index] == null)
-                return;
-            StateMachine.ChangeState<PlayerAttackState>();
-            stat.skills[index].UseSkill();
+            stat.currentHealthPoint -= ElementalBalancer.ApplyBalance(data.ElementalType, stat.elementalType, data.Damage);
+            Effect effect = null;
+            ElementalBalancer.ApplyElementalEffect(data.ElementalType, ref effect);
+            if (effect != null)
+                Affected(effect);
         }
     }
 

--- a/Assets/Scripts/Actor/Stats/ActorStatObject.cs
+++ b/Assets/Scripts/Actor/Stats/ActorStatObject.cs
@@ -9,20 +9,22 @@ namespace Actor.Stats
 {
     public abstract class ActorStatObject : ScriptableObject
     {
-        protected bool isInitialized = false;
+        [SerializeField] protected bool isInitialized = false;
         
         public AttackSkillObject normalAttack;
         public SerializableDictionary<AttributeType, Attribute> baseAttributes = new();
-        public List<Effect> effects = new();
         public ElementalType elementalType;
         
         public float baseHealthPoint;
+
+        protected abstract void InitElementalType();
 
         protected virtual void OnEnable()
         {
             if (isInitialized)
                 return;
             isInitialized = true;
+            
             baseAttributes.Clear();
             // TODO: set initial stats
             foreach (AttributeType type in Enum.GetValues(typeof(AttributeType)))
@@ -30,129 +32,18 @@ namespace Actor.Stats
                 baseAttributes[type] = new Attribute(type, 10);
             }
             CalculateSideAttributes();
-            effects.Clear();
+            InitElementalType();
         }
 
         protected void CalculateSideAttributes()
         {
-            // TODO: calculate 
-            baseHealthPoint = baseAttributes[AttributeType.Health].value * 10;
-        }
-
-        public void AddEffect(Effect effect, Actor<ActorStatObject> target)
-        {
-            if (effects.Exists(e => e.type == effect.type))
-            {
-                if (effect.isPermanent)
-                    return;
-                else if (effect.isStackable)
-                {
-                    if (effect.overlappingCount == 1)
-                    {
-                        effects.Add(effect);
-                        effect.overlappingCount++;
-                    }
-                    else
-                    {
-                        float changeValue;
-                        switch (effect.type)
-                        {
-                            case EffectType.Burns:
-                                changeValue = effect.effectValue;
-                                baseHealthPoint -= changeValue;
-                                break;
-                            case EffectType.Frostbite:
-                                target.stat.baseAttributes[AttributeType.MoveSpeed].value = 0;
-                                break;
-                            case EffectType.Poison:
-                                changeValue = target.stat.baseAttributes[AttributeType.Health].value *
-                                              effect.effectValue;
-                                baseHealthPoint -= changeValue;
-                                break;
-                        }
-                    }
-                }
-                else
-                {
-                    var existingEffect = effects.Find(e => e.type == effect.type);
-                    existingEffect.duration = effect.duration;
-                }
-
-            }
-            // 새로운 상태이상을 적용하는 경우
-            else
-            {
-                effects.Add(effect);
-                if (effect.isStackable)
-                    effect.overlappingCount++;
-            }
-
-            /*switch (effect.type)
-            {
-                case EffectType.Bleeding:
-                {
-                    var changeValue = target.stat.entireHp * effect.effectivePoint;
-                    for (var i = effect.duration; (i -= deltaTime) > 0;)
-                    {
-                        HandleDotStatusEffect(actor, effect, changeValue, deltaTime);
-                        i -= deltaTime;
-                    }
-                    break;
-                }
-                case EffectType.Blind:
-                {
-                    target.stat.accuracyRate = 0;
-                    break;
-                }
-                case EffectType.Burns:
-                {
-                    var changeValue = effect.effectivePoint;
-                    for (var i = effect.duration; (i -= deltaTime) > 0;)
-                    {
-                        HandleDotStatusEffect(actor, effect, changeValue, deltaTime);
-                        i -= deltaTime;
-                    }
-                    break;
-                }
-                case EffectType.Confuse:
-                {
-    
-                    break;
-                }
-                case EffectType.Fracture:
-                {
-                    var changeValue = effect.effectivePoint;
-                    target.stat.moveSpeed -= changeValue;
-                    break;
-                }
-                case EffectType.Frostbite:
-                {
-                    var changeValue = effect.effectivePoint;
-                    target.stat.moveSpeed -= changeValue;
-                    break;
-                }
-                case EffectType.Paralysis:
-                {
-                    var changeValue = effect.effectivePoint;
-                    target.stat.atkSpeed -= changeValue;
-                    break;
-                }
-                case EffectType.Poison:
-                {
-                    var changeValue = target.stat.entireHp * effect.effectivePoint;
-                    for (var i = effect.duration; (i -= deltaTime) > 0;)
-                    {
-                        HandleDotStatusEffect(actor, effect, changeValue, deltaTime);
-                        i -= deltaTime;
-                    }
-                    break;
-                }
-
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }*/
+            baseAttributes[AttributeType.MoveSpeed] = baseAttributes[AttributeType.Speed];
+            baseAttributes[AttributeType.AttackSpeed] = baseAttributes[AttributeType.Speed];
+            baseAttributes[AttributeType.Accuracy] = baseAttributes[AttributeType.Health];
+            baseAttributes[AttributeType.Avoidance] = baseAttributes[AttributeType.Speed];
+            
+            baseHealthPoint = baseAttributes[AttributeType.Health].value * 100;
         }
     }
-
 }
         

--- a/Assets/Scripts/Actor/Stats/Effect.cs
+++ b/Assets/Scripts/Actor/Stats/Effect.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace Actor.Stats
 {
@@ -8,13 +9,17 @@ namespace Actor.Stats
     public class Effect
     {
         public EffectType type;
-        public bool isStackable;
+        
         public bool isPermanent;
-        public bool isRelease;
         public float duration;
+        
         public List<AttributeType> effectTo;
+        public bool isRelease;
+        public bool isMultiplication = false;
         public float effectValue;
-        public int overlappingCount;
+        
+        public bool isStackable;
+        public int stackCount;
 
         public int DisplayTime
         {
@@ -81,6 +86,14 @@ namespace Actor.Stats
                     break;
                 }
             }
+        }
+        
+        private float Add(float targetValue) => effectValue;
+        private float Multiply(float targetValue) => targetValue * effectValue;
+
+        public float GetValueToAdd(float targetValue)
+        {
+            return isMultiplication ? Multiply(targetValue) : Add(targetValue);
         }
     }
 }

--- a/Assets/Scripts/Actor/Stats/EnemyStatObject.cs
+++ b/Assets/Scripts/Actor/Stats/EnemyStatObject.cs
@@ -1,3 +1,4 @@
+using Elemental;
 using UnityEngine;
 
 namespace Actor.Stats
@@ -5,17 +6,17 @@ namespace Actor.Stats
     [CreateAssetMenu(fileName = "New Enemy Data", menuName = "Scriptable Object/Stat/EnemyStat")]
     public class EnemyStatObject : ActorStatObject
     {
+        protected override void InitElementalType()
+        {
+            elementalType = ElementalType.None;
+        }
+
         protected override void OnEnable()
         {
-            if (!isInitialized)
+            if (isInitialized)
                 return;
             
             base.OnEnable();
-        }
-        
-        public void AddEffect(Effect effect)
-        {
-            effects.Add(effect);
         }
     }
 }

--- a/Assets/Scripts/Actor/Stats/PlayerStatObject.cs
+++ b/Assets/Scripts/Actor/Stats/PlayerStatObject.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Collections.Generic;
+using Core;
+using Elemental;
 using Skill;
 using UnityEngine;
 
@@ -11,9 +15,12 @@ namespace Actor.Stats
         public SkillSlot[] skills = new SkillSlot[4];
         public SkillObject passive;
         
+        public SerializableDictionary<EffectType, Effect> effects = new();
+        
         private int _level = 1;
         private int _exp = 0;
 
+        public SerializableDictionary<AttributeType, Attribute> currentAttributes = new();
         public float currentHealthPoint;
 
         #endregion
@@ -26,13 +33,28 @@ namespace Actor.Stats
         #endregion
 
         #region PrivateMethods
+        
+        protected override void InitElementalType()
+        {
+            elementalType = passive ? passive.elementalType : ElementalType.None;
+        }
+        
+        #endregion
 
+        #region MonoBehaviourMethods
         protected override void OnEnable()
         {
-            if (!isInitialized)
+            if (isInitialized)
                 return;
             
             base.OnEnable();
+            effects.Clear();
+            currentAttributes.Clear();
+            foreach (AttributeType type in Enum.GetValues(typeof(AttributeType)))
+            {
+                currentAttributes[type] = new Attribute(type, baseAttributes[type].value);
+            }
+            
             skills[3].slotType = SkillType.Ultimate;
             currentHealthPoint = baseHealthPoint;
         }
@@ -48,6 +70,21 @@ namespace Actor.Stats
             // add attribute base value by level
         }
 
+        public void AddAttribute(AttributeType type, float value)
+        {
+            currentAttributes[type].value += value;
+        }
+
+        public void AddEffect(Effect effect)
+        {
+            
+        }
+
+        public void DeleteEffect(EffectType type)
+        {
+            
+        }
+        
         #endregion
     }
 }

--- a/Assets/Scripts/CustomEditor/AttackSkillCustomEditor.cs
+++ b/Assets/Scripts/CustomEditor/AttackSkillCustomEditor.cs
@@ -1,3 +1,4 @@
+using Cinemachine.Editor;
 using Skill;
 using UnityEditor;
 
@@ -9,26 +10,27 @@ namespace CustomEditor
         private SerializedProperty _type;
         private SerializedProperty _elementalType;
         private SerializedProperty _data;
-        private SerializedProperty _isUnlocked;
         
         private SerializedProperty _targetType;
         private SerializedProperty _hasDotDamage;
-        private SerializedProperty _hasEffect;
-        private SerializedProperty _isMultiplication;
 
         private SerializedProperty _range;
         private SerializedProperty _dotDamage;
         private SerializedProperty _dotDuration;
 
+        private SerializedProperty _hasEffect;
         private SerializedProperty _effect;
         private SerializedProperty _damage;
         private SerializedProperty _projectile;
 
         private void OnEnable()
         {
+            _type = serializedObject.FindProperty("type");
+            _elementalType = serializedObject.FindProperty("elementalType");
+            _data = serializedObject.FindProperty("data");
+        
             _targetType = serializedObject.FindProperty("targetType");
             _hasDotDamage = serializedObject.FindProperty("hasDotDamage");
-            _isMultiplication = serializedObject.FindProperty("isMultiplication");
 
             _range = serializedObject.FindProperty("range");
             _dotDamage = serializedObject.FindProperty("dotDamage");
@@ -42,6 +44,10 @@ namespace CustomEditor
 
         public override void OnInspectorGUI()
         {
+            EditorGUILayout.PropertyField(_type);
+            EditorGUILayout.PropertyField(_elementalType);
+            EditorGUILayout.PropertyField(_data);
+            
             EditorGUILayout.PropertyField(_targetType);
             EditorGUILayout.PropertyField(_damage);
             switch (_targetType.enumValueIndex)
@@ -65,7 +71,6 @@ namespace CustomEditor
             if (_hasEffect.boolValue)
             {
                 EditorGUILayout.PropertyField(_effect);
-                EditorGUILayout.PropertyField(_isMultiplication);
                 EditorGUILayout.HelpBox("If this skill has percent effect, mark [Is Multiplication] true", MessageType.Info);
             }
 

--- a/Assets/Scripts/CustomEditor/EffectSkillCustomEditor.cs
+++ b/Assets/Scripts/CustomEditor/EffectSkillCustomEditor.cs
@@ -6,6 +6,10 @@ namespace CustomEditor
     [UnityEditor.CustomEditor(typeof(EffectSkillObject))]
     public class EffectSkillCustomEditor : Editor
     {
+        private SerializedProperty _type;
+        private SerializedProperty _elementalType;
+        private SerializedProperty _data;
+        
         private SerializedProperty _targetType;
         private SerializedProperty _hasDotDamage;
         private SerializedProperty _isMultiplication;
@@ -18,6 +22,10 @@ namespace CustomEditor
 
         private void OnEnable()
         {
+            _type = serializedObject.FindProperty("type");
+            _elementalType = serializedObject.FindProperty("elementalType");
+            _data = serializedObject.FindProperty("data");
+            
             _targetType = serializedObject.FindProperty("targetType");
             _hasDotDamage = serializedObject.FindProperty("hasDotDamage");
             _isMultiplication = serializedObject.FindProperty("isMultiplication");
@@ -31,6 +39,10 @@ namespace CustomEditor
 
         public override void OnInspectorGUI()
         {
+            EditorGUILayout.PropertyField(_type);
+            EditorGUILayout.PropertyField(_elementalType);
+            EditorGUILayout.PropertyField(_data);
+            
             EditorGUILayout.PropertyField(_targetType);
             if (_targetType.enumValueIndex == (int)TargetType.Area)
             {

--- a/Assets/Scripts/Elemental/ElementalBalancer.cs
+++ b/Assets/Scripts/Elemental/ElementalBalancer.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Collections.Generic;
+using Actor.Stats;
+using Interface;
 
 namespace Elemental
 {
@@ -34,6 +37,88 @@ namespace Elemental
             if (Info[type].StrongTo == target)
                 return 2f * damage;
             return damage;
+        }
+
+        public static void ApplyElementalEffect(ElementalType type, ref Effect effect)
+        {
+            switch (type)
+            {
+                case ElementalType.Fire:
+                {
+                    if (GetProbability(EffectType.Burns))
+                    {
+                        effect = new Effect(EffectType.Burns, 10, 5);
+                    }
+
+                    break;
+                }
+                case ElementalType.Ice:
+                {
+                    if (GetProbability(EffectType.Frostbite))
+                    {
+                        effect = new Effect(EffectType.Frostbite, 10, 5);
+                    }
+
+                    break;
+                }
+                case ElementalType.Ground:
+                {
+                    if (GetProbability(EffectType.Fracture))
+                    {
+                        effect = new Effect(EffectType.Fracture, 5);
+                    }
+
+                    break;
+                }
+                case ElementalType.Wind:
+                {
+                    if (GetProbability(EffectType.Bleeding))
+                    {
+                        effect = new Effect(EffectType.Bleeding, 5);
+                    }
+
+                    break;
+                }
+                case ElementalType.Holy:
+                {
+                    if (GetProbability(EffectType.Blind))
+                    {
+                        effect = new Effect(EffectType.Blind, 10, 5);
+                    }
+
+                    break;
+                }
+                case ElementalType.Dark:
+                {
+                    if (GetProbability(EffectType.Blind))
+                    {
+                        effect = new Effect(EffectType.Blind, 10, 5);
+                    }
+
+                    break;
+                }
+                case ElementalType.Normal:
+                case ElementalType.None:
+                default:
+                    break;
+            }
+        }
+
+        private static bool GetProbability(EffectType type)
+        {
+            var rand = new Unity.Mathematics.Random();
+            var randDouble = rand.NextDouble();
+            if (type is EffectType.Bleeding or EffectType.Fracture)
+            {
+                if (randDouble < 0.01f)
+                    return true;
+            }
+            else
+            {
+                if (randDouble < 0.1f)
+                    return true;
+            }
+            return false;
         }
     }
 }

--- a/Assets/Scripts/Interface/IAffected.cs
+++ b/Assets/Scripts/Interface/IAffected.cs
@@ -5,7 +5,7 @@ namespace Interface
 {
     public interface IAffected
     {
-        void Affected(Effect effect, Func<float, float> getValueToAdd);
-        void Realeased(Effect effect);
+        void Affected(Effect effect);
+        void Released(Effect effect);
     }
 }

--- a/Assets/Scripts/ScriptableObjects/Skills/Player/Attack/ProjectileAttack.asset
+++ b/Assets/Scripts/ScriptableObjects/Skills/Player/Attack/ProjectileAttack.asset
@@ -12,8 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 91a3aec108cc4ea09b53199416e671ff, type: 3}
   m_Name: ProjectileAttack
   m_EditorClassIdentifier: 
-  type: 0
+  type: 2
   elementalType: 0
+  level: 0
   data:
     id: -1
     name: 
@@ -21,22 +22,32 @@ MonoBehaviour:
   targetType: 2
   hasDotDamage: 0
   hasEffect: 0
-  isMultiplication: 0
-  range: 0
   dotDamage:
     Damage: 0
     KbForce: {x: 0, y: 0, z: 0}
+    ElementalType: 0
   dotDuration: 0
   effect:
     type: 0
-    isStackable: 0
     isPermanent: 0
     duration: 0
-    effectTo: 0
+    effectTo: 
+    isRelease: 0
+    isMultiplication: 0
     effectValue: 0
+    isStackable: 0
+    stackCount: 0
+  coolTime: 0
+  activeSpeed: 0
+  range: 0
+  changeValueE: 0
+  changeValueC: 0
+  changeValueA: 0
+  changeValueD: 0
   _damage:
     Damage: 5
     KbForce: {x: 0, y: 0, z: 0}
+    ElementalType: 0
   _projectile:
     sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
     radius: 0.5

--- a/Assets/Scripts/ScriptableObjects/Skills/Player/Attack/WorldAttack.asset
+++ b/Assets/Scripts/ScriptableObjects/Skills/Player/Attack/WorldAttack.asset
@@ -12,22 +12,43 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 91a3aec108cc4ea09b53199416e671ff, type: 3}
   m_Name: WorldAttack
   m_EditorClassIdentifier: 
-  type: 2
+  type: 5
   elementalType: 0
+  level: 0
   data:
     id: -1
     name: World Attack
     description: 
   targetType: 4
-  isDotEffect: 0
-  isMultiplication: 0
-  range: 0
-  duration: 0
+  hasDotDamage: 0
+  hasEffect: 0
   dotDamage:
     Damage: 0
     KbForce: {x: 0, y: 0, z: 0}
-  effectTo: 0
-  effectValue: 0
+    ElementalType: 0
+  dotDuration: 0
+  effect:
+    type: 0
+    isPermanent: 0
+    duration: 0
+    effectTo: 
+    isRelease: 0
+    isMultiplication: 0
+    effectValue: 0
+    isStackable: 0
+    stackCount: 0
+  coolTime: 0
+  activeSpeed: 0
+  range: 0
+  changeValueE: 0
+  changeValueC: 0
+  changeValueA: 0
+  changeValueD: 0
   _damage:
     Damage: 10
     KbForce: {x: 0, y: 0, z: 0}
+    ElementalType: 0
+  _projectile:
+    sprite: {fileID: 0}
+    radius: 0
+    speed: 0

--- a/Assets/Scripts/ScriptableObjects/Stats/Default Enemy.asset
+++ b/Assets/Scripts/ScriptableObjects/Stats/Default Enemy.asset
@@ -12,25 +12,26 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b5009c0d7f264b948a3002f5e54b4c8d, type: 3}
   m_Name: Default Enemy
   m_EditorClassIdentifier: 
+  isInitialized: 1
   normalAttack: {fileID: 0}
   baseAttributes:
     keys: 0000000001000000020000000300000004000000050000000600000007000000
     values:
     - type: 0
-      value: 1
+      value: 10
     - type: 1
       value: 1
     - type: 2
       value: 1
     - type: 3
-      value: 1
+      value: 10
     - type: 4
-      value: 1
+      value: 10
     - type: 5
-      value: 1
+      value: 10
     - type: 6
       value: 10
     - type: 7
       value: 10
-  effects: []
-  baseHealthPoint: 10
+  elementalType: 7
+  baseHealthPoint: 1000

--- a/Assets/Scripts/ScriptableObjects/Stats/Player Data.asset
+++ b/Assets/Scripts/ScriptableObjects/Stats/Player Data.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b702b10af9fb4e58ad395c7cc28030d1, type: 3}
   m_Name: Player Data
   m_EditorClassIdentifier: 
+  isInitialized: 1
   normalAttack: {fileID: 11400000, guid: 11512af680c6ad14b84eb49880770cf1, type: 2}
   baseAttributes:
     keys: 0000000001000000020000000300000004000000050000000600000007000000
@@ -32,8 +33,8 @@ MonoBehaviour:
       value: 10
     - type: 7
       value: 10
-  effects: []
-  baseHealthPoint: 100
+  elementalType: 7
+  baseHealthPoint: 1000
   skills:
   - slotType: 2
     _skillObject: {fileID: 11400000, guid: cf985d9a164daf24fb36317bf67bc7c1, type: 2}
@@ -41,7 +42,29 @@ MonoBehaviour:
     _skillObject: {fileID: 0}
   - slotType: 2
     _skillObject: {fileID: 0}
-  - slotType: 3
+  - slotType: 5
     _skillObject: {fileID: 11400000, guid: f8f0cf0fac7de9d47bf8d01a9277aa98, type: 2}
   passive: {fileID: 0}
-  currentHealthPoint: 9175
+  effects:
+    keys: 
+    values: []
+  currentAttributes:
+    keys: 0000000001000000020000000300000004000000050000000600000007000000
+    values:
+    - type: 0
+      value: 10
+    - type: 1
+      value: 10
+    - type: 2
+      value: 10
+    - type: 3
+      value: 10
+    - type: 4
+      value: 10
+    - type: 5
+      value: 10
+    - type: 6
+      value: 10
+    - type: 7
+      value: 10
+  currentHealthPoint: 960

--- a/Assets/Scripts/Skill/ActiveSkillObject.cs
+++ b/Assets/Scripts/Skill/ActiveSkillObject.cs
@@ -10,7 +10,6 @@ namespace Skill
         [SerializeField] protected TargetType targetType;
         [SerializeField] protected bool hasDotDamage = false;
         [SerializeField] protected bool hasEffect = false;
-        [SerializeField] protected bool isMultiplication = false;
         
         [SerializeField] protected DamageData dotDamage;
         [SerializeField] protected float dotDuration;
@@ -55,8 +54,5 @@ namespace Skill
         {
             return null;
         }
-
-        protected float Add(float targetValue) => effect.effectValue;
-        protected float Multiply(float targetValue) => targetValue * effect.effectValue;
     }
 }

--- a/Assets/Scripts/Skill/AttackSkillObject.cs
+++ b/Assets/Scripts/Skill/AttackSkillObject.cs
@@ -1,6 +1,3 @@
-using Actor;
-using Actor.Stats;
-using Elemental;
 using Interface;
 using Skill.Projectile;
 using Skill.Strategy;
@@ -44,86 +41,9 @@ namespace Skill
             target.GetComponent<IDamageable>()?.Damaged(_damage);
             if (hasEffect)
             {
-                target.GetComponent<IAffected>()?.Affected(effect, isMultiplication ? Multiply : Add);
+                target.GetComponent<IAffected>()?.Affected(effect);
             }
         }
-        
-        public void EffectDetermination(Actor<ActorStatObject> target)
-        {
-            switch (_damage.ElementalType)
-            {
-                case ElementalType.Fire:
-                {
-                    if (target.stat.elementalType == ElementalType.Wind)
-                        _damage.Damage *= 2;
-                    var effect = new Effect(EffectType.Burns, 10, 5);
-                    AffectedConfirm(target, effect);
-                    break;
-                }
-                case ElementalType.Ice:
-                {
-                    if (target.stat.elementalType == ElementalType.Fire)
-                        _damage.Damage *= 2;
-                    var effect = new Effect(EffectType.Frostbite, 10, 5);
-                    AffectedConfirm(target, effect);
-                    break;
-                }
-                case ElementalType.Ground:
-                {
-                    if (target.stat.elementalType == ElementalType.Ice)
-                        _damage.Damage *= 2;
-                    var effect = new Effect(EffectType.Fracture, 5);
-                    AffectedConfirm(target, effect);
-                    break;
-                }
-                case ElementalType.Wind:
-                {
-                    if (target.stat.elementalType == ElementalType.Ground)
-                        _damage.Damage *= 2;
-                    var effect = new Effect(EffectType.Bleeding, 5);
-                    AffectedConfirm(target, effect);
-                    break;
-                }
-                case ElementalType.Holy:
-                {
-                    if (target.stat.elementalType == ElementalType.Dark)
-                        _damage.Damage *= 2;
-                    var effect = new Effect(EffectType.Blind, 10, 5);
-                    AffectedConfirm(target, effect);
-                    break;
-                }
-                case ElementalType.Dark:
-                {
-                    if (target.stat.elementalType == ElementalType.Holy)
-                        _damage.Damage *= 2;
-                    var effect = new Effect(EffectType.Blind, 10, 5);
-                    AffectedConfirm(target, effect);
-                    break;
-                }
-            }
-        }
-        
-         private static void AffectedConfirm(Actor<ActorStatObject> target, Effect effect)
-         {
-             var rand = new Unity.Mathematics.Random();
-             var randDouble = rand.NextDouble();
-             if (effect.type is EffectType.Bleeding or EffectType.Fracture)
-             {
-                 if(randDouble < 0.01f)
-                     Affected(target, effect);
-             }
-             else
-             {
-                 if(randDouble < 0.1f)
-                     Affected(target, effect);
-             }
-         }
-         
-         private static void Affected(Actor<ActorStatObject> target, Effect effect)
-         {
-             target.skillEffectValues[effect.effectTo[0]] = effect.effectValue;
-             target.stat.effects.Add(effect);
-         }
     }
     
 }

--- a/Assets/Scripts/Skill/EffectSkillObject.cs
+++ b/Assets/Scripts/Skill/EffectSkillObject.cs
@@ -23,14 +23,14 @@ namespace Skill
                     if (_effect.isRelease)
                         //context.GameObject.GetComponent<IAffected>().EffectRelease(_effect);
                     //else
-                        context.GameObject.GetComponent<IAffected>().Affected(_effect, isMultiplication ? Multiply : Add);
+                        context.GameObject.GetComponent<IAffected>().Affected(_effect);
                     break;
                 }
                 case TargetType.Single:
                 {
                     var target = GetTarget();
                     if (hasDotDamage)
-                        target.GetComponent<IAffected>().Affected(_effect, isMultiplication ? Multiply : Add);
+                        target.GetComponent<IAffected>().Affected(_effect);
                     target.GetComponent<IDamageable>().DotDamaged(dotDamage, dotDuration);
                     break;
                 }

--- a/Assets/Scripts/Skill/SkillObject.cs
+++ b/Assets/Scripts/Skill/SkillObject.cs
@@ -11,7 +11,7 @@ namespace Skill
         public ElementalType elementalType;
         public int level;
         
-        [SerializeField] protected global::Skill.Skill data;
+        [SerializeField] protected Skill data;
         protected bool isUnlocked = false;
         
         public int Id


### PR DESCRIPTION
1. ActorStatObject, PlayerStatObject, EnemyStatObject, Actor, Player, Enemy 간에 서로서로 중복되거나 헷갈리는 데이터들을 수정했습니다..ㅜㅜ 

체력 바에 필요한 체력 퍼센트는 Player의 PercentHealPoint 프로퍼티
다른 스탯들은 Player의 GetAttributeValue 메서드

로 참조하시면 됩니다

2. 하다보니 스킬 부분의 이펙트 계산기 부분도 조금 리팩토링 했습니다.. 하지만 아직 여전히 동작은 안됩니다